### PR TITLE
Fix regular venv

### DIFF
--- a/pytomata.zsh
+++ b/pytomata.zsh
@@ -31,10 +31,13 @@ delenv() {
 }
 
 denv() {
-    if [[ $VIRTUAL_ENV ]] && [[ ! $PYTOMATA_ON ]]; then
-        deactivate
-    else
+    if [[ $VIRTUAL_ENV ]] && [[ $PYTOMATA_ON ]]; then
         pyenv deactivate 2> /dev/null && {export PATH="$original_path"; unset PYTOMATA_ON}
+        return 0
+    elif [[ $VIRTUAL_ENV ]] && [[ ! $PYTOMATA_ON ]]; then
+        return 0
+    else
+        return 1
     fi
 }
 
@@ -149,7 +152,10 @@ upenv() {
 
 automata() {
     denv
+    retval=$?
     cat .env 2>/dev/null | grep -qw "HAS_PYENV_VIRTUALENV=\'true\'" || return 0
-    find ~/.pyenv/versions -maxdepth 1 -type l | rev | cut -d"/" -f1 | rev | grep -qw "${PWD##*/}" && aenv ${PWD##*/}
+    if [[ $retval -eq 1 ]]; then
+        find ~/.pyenv/versions -maxdepth 1 -type l | rev | cut -d"/" -f1 | rev | grep -qw "${PWD##*/}" && aenv ${PWD##*/}
+    fi
     return 0
 }

--- a/pytomata.zsh
+++ b/pytomata.zsh
@@ -99,7 +99,6 @@ uppip() {
 
 upenv() {
     not_venv="You must first activate the target venv. Aborting."
-    cannot_upgrade="Cannot upgrade. $current_version is the only Python version installed. Aborting."
 
     [[ ! $VIRTUAL_ENV ]] && echo $not_venv && return 1
     current_venv=$(pyenv version-name)
@@ -108,7 +107,7 @@ upenv() {
     available_versions[(r)$current_version]=()
     echo -n "Current venv version: "; echo $current_version
     if [[ $#available_versions -eq 0 ]]; then
-        echo $cannot_upgrade
+        echo "Cannot upgrade. $current_version is the only Python version installed. Aborting."
         return 1
     elif [[ $#available_versions -eq 1 ]]; then
         answer=1


### PR DESCRIPTION
## What?
I wrote a simple solution for an issue when I would rather use a regular venv (`python -m venv`)
from the Python3 venv module.

## Why?
During the rather short life of this plugin I already run multiple times into the problem that when
I had the regular venv activated and I would change the directory, pyto mata would cause a fatal
error that would effectively make my terminal instance unusable -- not a good design.

I additionally thought that if I use a regular venv instead of pytomata's, I would like to make it
behave like one. That is why, if a non-pytomata venv is activated, it will not be turned off. User will
have to turn it off manually (e.g. by the `deactivate` command).

## How?
I added a global variable `PYTOMATA_ON` that is set once a pytomata's venv is being activated.
It is being unset when the pytomata's venv is being deactivated.

## Testing?
Manual, for the following scenarios:

| venv on? | pytomata dir? | step | expected result | result |
| :---: | :---: | ----- | ----- | ----- |
| - | - | going into pytomata dir | pytomata turns on | Pass |
| - | + | going out of pytomata dir | pytomata turns off | Pass |
| + | - | going into pytomata dir | venv still on | Pass |
| + | + | going out of pytomata dir | venv still on | Pass |
| + | + | turning venv off | venv off, pytomata off | Pass |
| - | + | turning pytomata off | pytomata turns off | Pass |

## Screenshots (optional)
N/A

## Anything Else?
Additionally:
* Small readability improvements.
* Fix for not displaying current python version in `upenv()`

Next up, I will try to make pytomata's venv more persistent as well.